### PR TITLE
Changed the way the license is described. ライセンスの表記の仕方を変えた

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           tar -Jxvf ffmpeg-n5.0-latest-linux64-lgpl-5.0.tar.xz
           mv ffmpeg-n5.0-latest-linux64-lgpl-5.0/bin/ffmpeg ffmpeg
           rm -rf ffmpeg-n5.0-latest-linux64-lgpl-5.0/ ffmpeg-n5.0-latest-linux64-lgpl-5.0.tar.xz
-          poetry run pip-licenses --format=html --with-authors --with-urls --output-file=LICENSES.html
+          poetry run python -m pip-licenses --format=html --with-authors --with-urls --output-file=LICENSES.html
           cd ..
           mv run.dist ${{ steps.version.outputs.filename }}-linux
           zip -r ${{ steps.version.outputs.filename }}-linux.zip ${{ steps.version.outputs.filename }}-linux
@@ -70,7 +70,7 @@ jobs:
           Expand-Archive ffmpeg-n5.0-latest-win64-lgpl-5.0.zip
           mv ffmpeg-n5.0-latest-win64-lgpl-5.0/bin/ffmpeg ffmpeg.exe
           rm -rf ffmpeg-n5.0-latest-win64-lgpl-5.0/ ffmpeg-n5.0-latest-win64-lgpl-5.0.zip
-          poetry run pip-licenses  --format=html --with-authors --with-urls --output-file=LICENSES.html
+          poetry run python -m pip-licenses  --format=html --with-authors --with-urls --output-file=LICENSES.html
           cd ..
           mv run.dist ${{ steps.version.outputs.filename }}-windows
           Compress-Archive ${{ steps.version.outputs.filename }}-windows ${{ steps.version.outputs.filename }}-windows.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
-          poetry run python -m nuitka --assume-yes-for-downloads --standalone --no-prefer-source-code run.py
+          poetry run python -m nuitka --assume-yes-for-downloads --standalone --no-prefer-source-code --msvc=14.3 --include-package=websockets run.py
           cd run.dist
           curl -OL https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n5.0-latest-win64-lgpl-5.0.zip
           Expand-Archive ffmpeg-n5.0-latest-win64-lgpl-5.0.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
           tar -Jxvf ffmpeg-n5.0-latest-linux64-lgpl-5.0.tar.xz
           mv ffmpeg-n5.0-latest-linux64-lgpl-5.0/bin/ffmpeg ffmpeg
           rm -rf ffmpeg-n5.0-latest-linux64-lgpl-5.0/ ffmpeg-n5.0-latest-linux64-lgpl-5.0.tar.xz
+          poetry run pip-licenses --format=html --with-authors --with-urls --output-file=LICENSES.html
           cd ..
           mv run.dist ${{ steps.version.outputs.filename }}-linux
           zip -r ${{ steps.version.outputs.filename }}-linux.zip ${{ steps.version.outputs.filename }}-linux
@@ -61,17 +62,18 @@ jobs:
 
       - name: build for Windows
         if: matrix.os == 'windows-latest'
-        shell: bash
+        shell: pwsh
         run: |
           poetry run python -m nuitka --assume-yes-for-downloads --standalone --no-prefer-source-code run.py
           cd run.dist
           curl -OL https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n5.0-latest-win64-lgpl-5.0.zip
-          unzip ffmpeg-n5.0-latest-win64-lgpl-5.0.zip
+          Expand-Archive ffmpeg-n5.0-latest-win64-lgpl-5.0.zip
           mv ffmpeg-n5.0-latest-win64-lgpl-5.0/bin/ffmpeg ffmpeg.exe
           rm -rf ffmpeg-n5.0-latest-win64-lgpl-5.0/ ffmpeg-n5.0-latest-win64-lgpl-5.0.zip
+          poetry run pip-licenses  --format=html --with-authors --with-urls --output-file=LICENSES.html
           cd ..
           mv run.dist ${{ steps.version.outputs.filename }}-windows
-          powershell compress-archive ${{ steps.version.outputs.filename }}-windows ${{ steps.version.outputs.filename }}-windows.zip
+          Compress-Archive ${{ steps.version.outputs.filename }}-windows ${{ steps.version.outputs.filename }}-windows.zip
 
       - name: GH Release
         uses: softprops/action-gh-release@v0.1.14

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FFu-core
 
-このソフトウェアはFFu(本体はまだ開発中です)のcoreソフトフェアです。
+このソフトウェアは[FFu](https://github.com/My-MC/FFu)のcoreソフトフェアです。
 
 ## About
 
@@ -37,40 +37,4 @@ docker exec -it ffu-core bash
 
 ## LICENCE
 
-このソフトウェアのライセンスはMITライセンスです。またこのソフトウェアで使われているソフトウェアおよび、パッケージのライセンスは以下の通りです。
-
-Copyright © 2001-2020 Python Software Foundation; All Rights Reserved
-This software uses libraries from the FFmpeg project under the LGPLv2.1
-
-Name|Version|License|Author|URL|
-:-:|-|-|-|-|
-Nuitka|0.7.7|Apache Software License|Kay Hayen|<https://nuitka.net>|
-PySocks|1.7.1|BSD|Anorov|<https://github.com/Anorov/PySocks>|
-Pygments|2.11.2|BSD License|Georg Brandl|<https://pygments.org/>|
-anyio|3.5.0|MIT License|Alex Grönholm|UNKNOWN|
-asgiref|3.5.0|BSD License|Django Software Foundation|<https://github.com/django/asgiref/>|
-black|22.3.0|MIT License|Łukasz Langa|<https://github.com/psf/black>|
-certifi|2021.10.8|Mozilla Public License 2.0 (MPL 2.0)|Kenneth Reitz|<https://certifiio.readthedocs.io/en/latest/>|
-charset-normalizer|2.0.12|MIT License|Ahmed TAHRI @Ousret|<https://github.com/ousret/charset_normalizer>|
-click|8.1.2|BSD License|Armin Ronacher|<https://palletsprojects.com/p/click/>|
-colorama|0.4.4|BSD License|Jonathan Hartley|<https://github.com/tartley/colorama>|
-defusedxml|0.7.1|Python Software Foundation License|Christian Heimes|<https://github.com/tiran/defusedxml>|
-fastapi|0.75.1|MIT License|Sebastián Ramírez|<https://github.com/tiangolo/fastapi>|
-ffmpegwithpy|0.1.0|MIT license|My|<https://github.com/My-MC/ffmpegwithpy>|
-h11|0.13.0|MIT License|Nathaniel J. Smith|<https://github.com/python-hyper/h11>|
-httpie|3.1.0|BSD License|Jakub Roztocil|<https://httpie.io/>|
-idna|3.3|BSD License|Kim Davies|<https://github.com/kjd/idna>|
-isort|5.10.1|MIT License|Timothy Crosley|<https://pycqa.github.io/isort/>|
-multidict|6.0.2|Apache Software License|Andrew Svetlov|<https://github.com/aio-libs/multidict>|
-mypy-extensions|0.4.3|MIT License|The mypy developers|<https://github.com/python/mypy_extensions>|
-pathspec|0.9.0|Mozilla Public License 2.0 (MPL 2.0)|Caleb P. Burns|<https://github.com/cpburnz/python-path-specification>|
-platformdirs|2.5.1|MIT License|UNKNOWN|<https://github.com/platformdirs/platformdirs>|
-pydantic|1.9.0|MIT License|Samuel Colvin|<https://github.com/samuelcolvin/pydantic>|
-requests|2.27.1|Apache Software License|Kenneth Reitz|<https://requests.readthedocs.io>|
-requests-toolbelt|0.9.1|Apache Software License|Ian Cordasco, Cory Benfield|<https://toolbelt.readthedocs.org>|
-sniffio|1.2.0|Apache Software License; MIT License|Nathaniel J. Smith|<https://github.com/python-trio/sniffio>|
-starlette|0.17.1|BSD License|Tom Christie|<https://github.com/encode/starlette>|
-tomli|2.0.1|MIT License|UNKNOWN|UNKNOWN
-typing-extensions|4.1.1|Python Software Foundation License|UNKNOWN|UNKNOWN
-urllib3|1.26.9|MIT License|Andrey Petrov|<https://urllib3.readthedocs.io/>
-uvicorn|0.17.6|BSD License|Tom Christie|<https://www.uvicorn.org/>
+このソフトウェアのライセンスはMITライセンスです

--- a/poetry.lock
+++ b/poetry.lock
@@ -124,18 +124,21 @@ test = ["pytest (>=6.2.4,<7.0.0)", "pytest-cov (>=2.12.0,<4.0.0)", "mypy (==0.91
 
 [[package]]
 name = "ffmpegwithpy"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python FFmpeg wrapper."
 category = "main"
 optional = false
 python-versions = "^3.7"
 develop = false
 
+[package.dependencies]
+pydantic = "^1.9.1"
+
 [package.source]
 type = "git"
 url = "https://github.com/My-MC/ffmpegwithpy.git"
 reference = "master"
-resolved_reference = "a8955042ce4bf26f53b47888c6e41534983bc4ea"
+resolved_reference = "ed5caf6bdc371583c5904480866f7ac8a15806be"
 
 [[package]]
 name = "h11"
@@ -401,7 +404,7 @@ standard = ["websockets (>=10.0)", "httptools (>=0.4.0)", "watchgod (>=0.6)", "p
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "f18bac83cfe464f4293bf4171c64b6d14df38e780f61d1fed95d5b75197772f5"
+content-hash = "ea0aed989416d15546fc80abe4fc13eabc4099a456a024aab4467acba803698c"
 
 [metadata.files]
 anyio = [


### PR DESCRIPTION
README.mdに書いていると、パッケージを更新したりするときに更新し忘れたりしてしまうのでビルド時にLICENSES.htmlにして出力するようにした。それに付け加えて、bashを使っているからもしかしたらmsvcが使われていない疑惑があったりしたので、pwshに変更した